### PR TITLE
docs(readme): README の見出し・改行・句読点を推敲（Issue #73）

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ MCP ツール名（`/mdn_trans_*` など）の対応は次のとおりです。
 | — | `/translation_rules` | 表記・L10N リンク等の JSON |
 
 
-## 🗂️ パスの解決順（MCP ツール `/mdn_workspace_paths`）
+## 🗂️ パスの解決順
+
+対象 MCP ツール: `/mdn_workspace_paths`
 
 1. **環境変数（任意）** — `MDN_CONTENT_ROOT` と `MDN_TRANSLATED_CONTENT_ROOT` を**両方**指定すると、その絶対パスをそのまま使います。  
    片方だけの指定はできません（誤設定防止のためエラーになります）。
@@ -139,7 +141,9 @@ MCP ツール名（`/mdn_trans_*` など）の対応は次のとおりです。
 **リポジトリ実体** — 解決した `content` 相当のルートには `files/en-us` が、`translated-content` 相当のルートには `files/ja` がそれぞれディレクトリとして存在する必要があります（公式リポジトリを clone した状態）。  
 名前だけの空フォルダではエラーになります。
 
-## 📚 用語集 JSON（ツール `/mdn_glossary_replacement_candidates` / `/mdn_glossary_apply`）
+## 📚 用語集 JSON
+
+関連 MCP ツール: `/mdn_glossary_replacement_candidates` / `/mdn_glossary_apply`
 
 `{{glossary("term")}}` の第2引数（表示名）の置換候補は、
 [src/shared/data/glossary-terms.json](src/shared/data/glossary-terms.json) をビルド時に `dist/shared/data/` にコピーしたものを既定で参照します。


### PR DESCRIPTION
## 目的

- [Issue #73](https://github.com/gurezo/mdn-translation-ja-mcp/issues/73) に沿って README の見出し・折り返し・句読点を整理する。
- [開発コンセプト（Wiki）](https://github.com/gurezo/mdn-translation-ja-mcp/wiki/mdn%E2%80%90translation%E2%80%90ja%E2%80%90mcp-%E9%96%8B%E7%99%BA%E3%82%B3%E3%83%B3%E3%82%BB%E3%83%97%E3%83%88) の前提・ツール対応と矛盾がないことを確認する。

## 変更内容

- 見出し: セクションに絵文字を揃え、パス解決・用語集は短い見出し＋本文でツール名を記載。
- 折り返し: 長文の改行、トラブルシュート表の整理（セル内改行など）。
- 句読点: 概要・目的・注意・ライセンスなどの箇条書き末尾を統一。

## コミット（Conventional Commits）

- `docs(readme): 見出しに絵文字を統一`
- `docs(readme): 長文の改行とトラブルシュート表の可読性を調整`
- `docs(readme): 句読点と箇条書き末尾を統一`
- `docs(readme): パス解決と用語集の見出しを短くしツール名を本文へ分離`

Closes #73

Made with [Cursor](https://cursor.com)